### PR TITLE
fix fail_on_error input

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -24,4 +24,7 @@ ansible-lint -p ${INPUT_ANSIBLELINT_FLAGS} \
       -filter-mode="${INPUT_FILTER_MODE}" \
       -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
       ${INPUT_REVIEWDOG_FLAGS}
+exit_code=$?
 echo '::endgroup::'
+
+exit $exit_code


### PR DESCRIPTION
fixed it.
https://github.com/reviewdog/reviewdog/issues/949

When fail_on_error is true and lint is failed, job is not failed.

## test

https://github.com/Doarakko/reviewdog-playground/pull/12

- `reviewdog / runner / ansible-lint (pull_request)`
    - master branch
- `reviewdog / runner / fix-ansible-lint (pull_request) `
    - my fixed branch 

![](https://user-images.githubusercontent.com/21009186/118371648-8b5b7900-b5e8-11eb-9def-e8c7a8543dee.png)
