### PR TITLE
bump Python v3.11

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.6
+          python-version: "3.11"
 
       - name: ansible-lint github-pr-check
         uses: ./


### PR DESCRIPTION
Python 3.6 is no longer supported.

https://github.com/reviewdog/action-ansiblelint/actions/runs/5323036471/jobs/9640282375?pr=28

```
  Version 3.6 was not found in the local cache
  Error: The version '3.6' with architecture 'x64' was not found for Ubuntu 22.04.
  The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```

I bumped Python to v3.11.