### PR TITLE
The installation of `ansible` relies on the dependencies of `ansible-lint`

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Optional. Additional reviewdog flags.
 
 ### `ansiblelint_version`
 
-Optional. The ansible-lint version to use. Default is `5.3.2`.
+Optional. The ansible-lint version to use. Default is `24.12.2`.
 
 ### `ansiblellint_flags`
 

--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,7 @@ inputs:
     default: "."
   ansiblelint_version:
     description: "The ansible-lint version to use"
-    default: "5.3.2"
+    default: "24.12.2"
   ansiblelint_flags:
     description: "Flags and args of ansible-lint command"
     default: ""

--- a/script.sh
+++ b/script.sh
@@ -10,7 +10,7 @@ curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.s
 echo '::endgroup::'
 
 echo '::group:: Installing ansible-lint ... https://github.com/ansible/ansible-lint'
-pip3 install --no-cache-dir ansible-lint=="${INPUT_ANSIBLELINT_VERSION}" "ansible>=2.9,<2.11"
+pip3 install --no-cache-dir ansible-lint=="${INPUT_ANSIBLELINT_VERSION}"
 echo '::endgroup::'
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"


### PR DESCRIPTION
## What

SSIA.

## Why

- https://github.com/reviewdog/action-ansiblelint/issues/46

## Remarks

I tested [244a5ac: ansible-lint v6 or later depends on ansible](https://github.com/reviewdog/action-ansiblelint/commit/244a5ac59a9e881e206ef575841fd1427a3ee0e7) in https://github.com/umatare5/actions-sandbox/pull/1.
