### PR TITLE
Allow caching via setup-python

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ jobs:
     name: runner / ansible-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: "3.6"
       - name: ansible-lint
@@ -88,7 +88,7 @@ To cache the `ansible`/`ansible-lint` installation, set the `cache` and
 `cache-dependency-path` input variables in the `setup-python` action, e.g.:
 
 ```yml
-      - uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: "3.6"
           cache: "pip"

--- a/README.md
+++ b/README.md
@@ -83,3 +83,14 @@ jobs:
           reporter: github-pr-review # Change reporter.
           ansiblelint_flags: '-x core playbook/*'
 ```
+
+To cache the `ansible`/`ansible-lint` installation, set the `cache` and
+`cache-dependency-path` input variables in the `setup-python` action, e.g.:
+
+```yml
+      - uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
+        with:
+          python-version: "3.6"
+          cache: "pip"
+          cache-dependency-path: ".github/workflows/lint.yml"
+```

--- a/script.sh
+++ b/script.sh
@@ -10,7 +10,7 @@ curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/fd59714416d6d9a1
 echo '::endgroup::'
 
 echo '::group:: Installing ansible-lint ... https://github.com/ansible/ansible-lint'
-pip3 install --no-cache-dir ansible-lint=="${INPUT_ANSIBLELINT_VERSION}" "ansible>=2.9,<2.11"
+pip3 install ansible-lint=="${INPUT_ANSIBLELINT_VERSION}" "ansible>=2.9,<2.11"
 echo '::endgroup::'
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"


### PR DESCRIPTION
It's unclear why `--no-cache-dir` is being used during tool installation here, but its use prevents caching of Python packages through the `setup-python` action (and other methods).

This should probably be considered a solution for #25.